### PR TITLE
Teams and sharepoint doc updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ results/
 **service_connection.json
 *.pyc
 __pycache__/
+.research/

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1052,7 +1052,7 @@ To enable GPT-RAG to use multimodal capabilities, such as those provided by GPT-
 
 ## SharePoint Setup
 
-The SharePoint connector indexes and purges files using scheduled Azure Functions to maintain an up-to-date Azure AI Search Index. For more information on how this works, see the Sharepoint section on the [Data Ingestion Page](https://github.com/Azure/gpt-rag-ingestion?tab=readme-ov-file#sharepoint-indexing). For detailed instructions on setting up SharePoint for data ingestion, please refer to the [SharePoint Setup Guide](INGESTION_SHAREPOINT_SETUP.md).
+The SharePoint connector indexes and purges files using scheduled Azure Functions to maintain an up-to-date Azure AI Search Index. The model is **pull-from-SharePoint, push-to-Search** &mdash; the ingestion Function App polls Microsoft Graph on a timer and upserts chunks directly into the `ragindex` Azure AI Search index (the Search service itself is never given access to SharePoint). This fork is pinned to [`gpt-rag-ingestion` `release/1.0.1`](https://github.com/Azure/gpt-rag-ingestion/tree/release/1.0.1); the [SharePoint Setup Guide](INGESTION_SHAREPOINT_SETUP.md) documents the matching environment variables, schedule, ACL handling (`metadata_security_id`), and known limits (single site/folder per Function App, no Graph paging beyond ~200 items per folder, secret-based auth). For background on the upstream connector, see the SharePoint section on the [Data Ingestion Page](https://github.com/Azure/gpt-rag-ingestion?tab=readme-ov-file#sharepoint-indexing).
 
 ## Speech Avatar Integration
 

--- a/docs/INGESTION_SHAREPOINT_SETUP.md
+++ b/docs/INGESTION_SHAREPOINT_SETUP.md
@@ -2,6 +2,42 @@
 
 This section explains how to configure SharePoint as a data source for the `ragindex` GPT-RAG Azure AI Search Index, using the `Sites.Selected` permission to limit access to specific site collections.
 
+> [!IMPORTANT]
+> **Tested ingestor version.** This fork (GPT-RAG-DCS) currently pins the ingestion Function App to
+> [`Azure/gpt-rag-ingestion` `release/1.0.1`](https://github.com/Azure/gpt-rag-ingestion/tree/release/1.0.1).
+> The behaviour described below &mdash; environment variables, schedule, supported formats, ACL handling,
+> and known limits &mdash; reflects that branch. Newer upstream releases (e.g. `main`/v2.x) change
+> the connector substantially and may not match this guide.
+
+## How the SharePoint connector works (1.0.1)
+
+The connector is built on a **pull-from-SharePoint, push-to-Search** model:
+
+- **Pull from SharePoint** &mdash; two timer-triggered Python Azure Functions inside the GPT-RAG
+  ingestion Function App poll Microsoft Graph on a schedule. SharePoint itself does not push events
+  to GPT-RAG (no webhook, no change-notification subscription, no Azure AI Search built-in
+  SharePoint indexer); discovery happens entirely via outbound Graph calls from the Function App.
+- **Push to Azure AI Search** &mdash; once a file is downloaded and chunked, the Function App
+  upserts the chunks + embeddings directly into the `ragindex` Azure AI Search index. The Search
+  service is never given direct access to SharePoint.
+
+The two functions are:
+
+| Function | Purpose | Trigger (per [`function_app.py`](https://github.com/Azure/gpt-rag-ingestion/blob/release/1.0.1/function_app.py) on `release/1.0.1`) |
+|---|---|---|
+| `sharepoint_index_files` | List files in the configured site/folder via Graph, decide which need (re-)indexing (by comparing `metadata_storage_last_modified`), download, chunk, embed, and upsert into `ragindex`. | Timer trigger. |
+| `sharepoint_purge_deleted_files` | Walk the index, ask Graph whether each indexed SharePoint file still exists, and delete index entries for files that no longer do. | `schedule="0 */60 * * * *"` &mdash; every 60&nbsp;minutes. |
+
+> [!NOTE]
+> The upstream README sometimes describes both functions as running every 10&nbsp;minutes. On the
+> `release/1.0.1` branch the purger's CRON expression is actually every 60&nbsp;minutes &mdash; verify
+> the schedule in `function_app.py` for the version you have deployed, and override via Function App
+> application settings if you need a different cadence.
+
+Both functions are gated by `SHAREPOINT_CONNECTOR_ENABLED=true`. Both target the **single**
+site + folder + file-format set defined by the `SHAREPOINT_*` environment variables below &mdash;
+1.0.1 does not support multiple sites or folders from one Function App.
+
 ### Prerequisites  
 
 Before executing this procedure ensure you have the necessary roles for each step:  
@@ -228,6 +264,10 @@ Before executing this procedure ensure you have the necessary roles for each ste
   >[!NOTE]
   > Leave `SHAREPOINT_FILES_FORMAT` empty to include the following default extensions: vtt, xlsx, xls, pdf, png, jpeg, jpg, bmp, tiff, docx, pptx.
 
+  > [!TIP]
+  > The target index name defaults to `ragindex`. If your deployment uses a different index, set
+  > `AZURE_SEARCH_SHAREPOINT_INDEX_NAME` on the Function App as well.
+
    - **Save and Restart**:
 
      - Click **Save** to apply the changes.
@@ -236,6 +276,47 @@ Before executing this procedure ensure you have the necessary roles for each ste
 
 > [!NOTE] 
 > Done! You have completed the SharePoint configuration procedure.
+
+## Known limits and operational notes (1.0.1)
+
+Keep these in mind when sizing a SharePoint deployment against the pinned 1.0.1 ingestor. None
+of them block normal use of small/medium document libraries, but they materially affect large or
+active ones.
+
+- **Single site / single folder per Function App.** The `SHAREPOINT_*` settings target one
+  site + one folder. To index multiple sites or multiple top-level folders, either deploy
+  additional Function Apps or wait for an upstream connector that supports a list of sources.
+- **Microsoft Graph paging is not implemented.** `sharepoint_files_indexer` reads only the first
+  page of `GET /drives/{id}/root/children` (Graph default ~200 items). Document libraries with
+  more than one page of matching files will silently have items beyond page&nbsp;1 omitted from
+  the index. Workarounds: partition into sub-folders below the configured root, or run separate
+  Function Apps per sub-folder.
+- **Moves and renames can produce duplicate index entries.** 1.0.1 keys index entries by the
+  SharePoint item ID and the purger checks per-item existence rather than using Graph delta
+  query. A file that is moved or renamed inside the indexed folder may appear under both old
+  and new identities until the purger removes the stale entry.
+- **No Graph 429 / `Retry-After` handling.** Large initial loads or rapid re-indexes can hit
+  Microsoft Graph throttling. If you see ingestion stalls, look in the Function App logs for HTTP
+  429 responses from `graph.microsoft.com` and consider lowering the cadence, narrowing
+  `SHAREPOINT_FILES_FORMAT`, or partitioning by folder.
+- **ACLs are partially captured, not fully trimmed end-to-end.** The connector reads each
+  file's read-permission users and groups via Graph and writes them to the
+  `metadata_security_id` field of every chunk (users from `grantedToIdentitiesV2` /
+  `grantedToIdentities`, groups from `grantedToV2.siteGroup.displayName`). Two caveats:
+  - Only the **file's own** permissions are read &mdash; permissions inherited from the
+    parent folder or site are not walked.
+  - Whether queries actually filter on `metadata_security_id` at runtime is a property of the
+    **orchestrator**, not the ingestor. Verify in the orchestrator before relying on per-user
+    security trimming for SharePoint content.
+- **Function timeout requires Premium/Dedicated.** The ingestion Function App's `host.json`
+  sets `functionTimeout: 01:00:00`, which exceeds the 10-minute Consumption-plan ceiling. The
+  Function App must run on a Premium or App Service (Dedicated) plan.
+- **Client secret rotation.** Auth uses the application client secret stored in the GPT-RAG
+  Key Vault as `sharepointClientSecret` (or whatever `SHAREPOINT_CLIENT_SECRET_NAME` points to).
+  Track the expiry you chose in step 4 above and rotate the Key Vault secret value before it
+  expires &mdash; ingestion will start failing with `AADSTS7000222`-style errors otherwise.
+  Federated identity credentials on the Function App's managed identity would remove this
+  rotation entirely, but are not implemented in the 1.0.1 connector.
 
 ## Validation
 

--- a/docs/TEAMS_INTEGRATION_MAIN.md
+++ b/docs/TEAMS_INTEGRATION_MAIN.md
@@ -1,40 +1,57 @@
 # Guide for Building a Teams App Interface for the Enterprise GPT-RAG Solution Accelerator
 
 ## Introduction
-This is a guide for building a Teams App Interface for the Enterprise GPT-RAG Solution Accelerator using Teams toolkit.
+This guide describes how to build a modern Teams chat experience for the Enterprise GPT-RAG Solution Accelerator using the **Microsoft 365 Agents Toolkit** (the evolution of the original *Teams Toolkit* for VS Code) and the **Teams AI Library v2**. The resulting bot connects to the GPT-RAG Orchestrator and surfaces answers with first-class RAG UX — token streaming, source citations, an "AI generated" label, and thumbs-up/thumbs-down feedback.
+
+> **What changed vs. previous versions of this guide.** Earlier revisions targeted the legacy *Teams Toolkit* with the *Basic Bot* template (Bot Framework SDK `ActivityHandler`). That stack is now in maintenance. This revision targets:
+>
+> - **Microsoft 365 Agents Toolkit** (renamed from *Teams Toolkit* in 2025).
+> - The **AI Chat Bot / Custom Engine Agent** project template, built on **Teams AI Library v2** (`@microsoft/teams-ai`).
+> - **Manifest schema v1.19+** so streaming, citations, the AI-generated label, and the feedback loop can be declared.
+> - **Reuse of existing GPT-RAG infrastructure** (VNet-integrated App Service or Function App) plus **private connectivity** to the orchestrator instead of provisioning a new public-facing App Service.
 
 ## Key Solution Components
-The following Azure resources will be deployed in addition to those already deployed in the Enterprise RAG Solution Accelerator.
-- Azure Bot Framework service
-- Azure App Service Plan & Azure App Service
-- Managed Identity
+The following are required in addition to those already deployed in the Enterprise RAG Solution Accelerator. **Reuse the accelerator's existing resources wherever possible** — see [Step 3](TEAMS_INTEGRATION_STEP3.md) for the reuse vs. greenfield decision.
+
+- **Azure Bot Service** — the messaging endpoint registration that connects Teams to the bot.
+- **Compute host** — one of:
+  - the **existing VNet-integrated App Service** from `infra/core/host/appservice.bicep`, or
+  - the **existing Function App** from `infra/core/host/functions.bicep` (HTTP-triggered), or
+  - a new App Service / Function App / Container App if isolation is required.
+- **User-Assigned Managed Identity** — used by the bot to (a) read configuration from Key Vault and (b) acquire tokens for the orchestrator (no shared secrets).
+- **Private endpoint or VNet integration** so the bot reaches the orchestrator over the same private network as the rest of the accelerator. The bot's *messaging endpoint* itself remains internet-reachable (Bot Service requires this), but **outbound** traffic to the orchestrator stays private.
+- **Entra ID app registration** for the bot, configured for **Teams SSO** so the user's identity can be flowed to the orchestrator via On-Behalf-Of (enables per-user security trimming).
 
 ## Prerequisites
-Before proceeding with the steps in the subsequent sections, ensure you have completed the following:
-- An Azure subscription to deploy the required resources.
-- A Microsoft 365 account. Read more on developer program that can be used for testing purposes. [here](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/tools-prerequisites#microsoft-365-developer-program).
-- The Enterprise GPT-RAG Solution Accelerator deployed in your Azure subscription.
-- For publishing, access to a Teams admin who can approve the app deployment within your organization. Alternatively, you can test locally on your development machine and/or use [custom upload](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) option if enabled for your organization.
-- Note: When deploying Azure resources for the Teams app, such as the App Service Plan and App Service, you can utilize the resources already provisioned in the GPT-RAG Solution Accelerator.
-- Note: The App Service uses a public endpoint for the Teams App to connect to the service.
+Before proceeding, ensure you have:
 
-Set up the following prerequisites on the machine to be used for development:
-- Download and install [Visual Studio Code](https://code.visualstudio.com/Download).
-- Install [NodeJS](https://nodejs.org/) version 16 or later.
+- An **Azure subscription** with permission to create Bot Service registrations and to assign roles on the existing accelerator resources.
+- A **Microsoft 365 tenant** account. For test tenants, see the [Microsoft 365 developer program](https://learn.microsoft.com/microsoftteams/platform/toolkit/tools-prerequisites#microsoft-365-developer-program).
+- The **Enterprise GPT-RAG Solution Accelerator** deployed in your subscription, with the orchestrator endpoint reachable from your chosen compute host.
+- For tenant publishing, access to a **Teams admin**. For individual testing, custom upload (sideloading) must be enabled in your tenant.
+- Permission to **create or update an Entra ID app registration** for the bot (required for SSO).
 
-## Step 1: [Create a new Teams App](TEAMS_INTEGRATION_STEP1.md).
+Set up the following on the development machine:
 
-## Step 2: [Connect to GPT-RAG Orchestrator and test locally](TEAMS_INTEGRATION_STEP2.md).
+- [Visual Studio Code](https://code.visualstudio.com/Download).
+- **Node.js 18 LTS or later** (Node 20 LTS recommended). The legacy Node 16 requirement no longer applies.
+- The **[Microsoft 365 Agents Toolkit](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)** extension for VS Code (this is the same Marketplace listing as the former *Teams Toolkit*; it self-rebranded).
+- Optional but recommended: the **Microsoft 365 Agents Toolkit CLI** (`@microsoft/m365agentstoolkit-cli`) for headless provisioning in CI.
 
-## Step 3: [Provision and Deploy the Azure resources for the Teams App](TEAMS_INTEGRATION_STEP3.md).
+## Steps
 
-## Step 4: [Build the Teams App](TEAMS_INTEGRATION_STEP4.md).
-
-## Step 5: [Publish the Teams App](TEAMS_INTEGRATION_STEP5.md).
+1. **[Create a new Teams app project](TEAMS_INTEGRATION_STEP1.md)** — scaffold an *AI Chat Bot* (Teams AI Library) project with the M365 Agents Toolkit.
+2. **[Connect to the GPT-RAG Orchestrator and test locally](TEAMS_INTEGRATION_STEP2.md)** — wire the Teams AI `Application` to the orchestrator with streaming, retries, and structured error handling.
+3. **[Provision and deploy Azure resources (reusing accelerator infra)](TEAMS_INTEGRATION_STEP3.md)** — host the bot on the existing VNet-integrated App Service or Function App and reach the orchestrator via private endpoint.
+4. **[Build the Teams app package](TEAMS_INTEGRATION_STEP4.md)** — produce the `.zip` for sideloading or store submission.
+5. **[Publish the Teams app](TEAMS_INTEGRATION_STEP5.md)** — sideload for testing or submit through the Developer Portal / tenant catalog.
+6. **[Add rich RAG UX (citations, streaming, AI label, feedback, SSO)](TEAMS_INTEGRATION_STEP6.md)** — turn the basic bot into a production-grade RAG agent.
 
 ## External Resources
-- [Microsoft Teams Toolkit Overview](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/teams-toolkit-fundamentals).
+- [Microsoft 365 Agents Toolkit overview](https://learn.microsoft.com/microsoftteams/platform/toolkit/teams-toolkit-fundamentals).
+- [Teams AI Library](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/teams%20conversational%20ai/teams-conversation-ai-overview).
+- [Microsoft 365 Agents SDK](https://learn.microsoft.com/microsoft-365/agents-sdk/).
 - [Visual Studio Code](https://code.visualstudio.com/Download).
-- [Install Teams Toolkit](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/install-teams-toolkit?tabs=vscode).
-- [Microsoft 365 developer program](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/tools-prerequisites#microsoft-365-developer-program).
+- [Microsoft 365 developer program](https://learn.microsoft.com/microsoftteams/platform/toolkit/tools-prerequisites#microsoft-365-developer-program).
+- [App manifest schema reference (v1.19+)](https://learn.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema).
 

--- a/docs/TEAMS_INTEGRATION_STEP1.md
+++ b/docs/TEAMS_INTEGRATION_STEP1.md
@@ -1,41 +1,74 @@
 # Guide for Building a Teams App Interface for Enterprise GPT-RAG Solution Accelerator
 
-*Ensure all prerequisites mentioned [here](TEAMS_INTEGRATION_MAIN.md) are completed before proceeding with the steps below.*
+*Ensure all prerequisites listed in [the main guide](TEAMS_INTEGRATION_MAIN.md#prerequisites) are completed before proceeding.*
 
-## Step 1: Create a new Teams App.
+## Step 1: Create a new Teams app project
 
-1. Open **Visual Studio Code**. 
+This step replaces the legacy *Teams Toolkit → Basic Bot* flow with the modern **Microsoft 365 Agents Toolkit → AI Chat Bot (Teams AI Library)** template. The AI Chat Bot template is purpose-built for LLM/RAG scenarios — it ships with first-class support for streaming, citations, the AI-generated content label, and the feedback loop that we configure in [Step 6](TEAMS_INTEGRATION_STEP6.md).
 
-2. Select the **Teams Toolkit** > **Create a New App**.
+### 1.1 Open the Agents Toolkit
 
-![Teams Toolkit, Create New App](../media/teams-guide-Step1a.png)
+1. Open **Visual Studio Code**.
+2. Select the **Microsoft 365 Agents Toolkit** icon in the sidebar (formerly *Teams Toolkit* — the extension self-rebranded; the Marketplace ID is unchanged).
+3. Choose **Create a New App** (or **Create a New Agent**, depending on the toolkit version).
 
-2. Select **Bot** as app capability.
+![Agents Toolkit, Create New App](../media/teams-guide-Step1a.png)
 
-![Bot](../media/teams-guide-Step1b.png)
+### 1.2 Choose the project type
 
-3. Select **Basic Bot** as app capability.
+1. Select **Agent / Bot** as the app capability.
+2. From the template list, choose **AI Chat Bot** (also labelled *Custom Engine Agent* in newer versions). Do **not** pick *Basic Bot* — that template is the legacy Bot Framework starter and lacks the RAG-specific primitives this guide relies on.
 
-![Basic Bot](../media/teams-guide-Step1c.png)
+   > If you want the same project to also be invokable from **Microsoft 365 Copilot Chat**, select the *Custom Engine Agent* variant. The Teams scope and the Copilot scope share the same code; only the manifest differs.
 
-4. Choose a programming language. For this guide, we will use **TypeScript**.
+3. Choose **TypeScript** as the programming language. (The same flow works for JavaScript, Python and C#; this guide uses TypeScript for parity with the prior revision.)
+4. Select a **Large Language Model** option of **Azure OpenAI** when prompted. This only seeds local config keys — the app will actually call the GPT-RAG Orchestrator (which fronts Azure OpenAI), wired up in [Step 2](TEAMS_INTEGRATION_STEP2.md). Leave the model name as the default for now.
+5. Select **Browse** and pick a folder for the project workspace.
+6. Enter an application name such as `GPTRAGTeams` (alphanumeric only). Press **Enter**.
 
-![Typescript](../media/teams-guide-Step1d.png)
+### 1.3 Verify the generated project
 
-5. Select **Browse** and select the location for project workspace.
+After scaffolding completes, the workspace should contain:
 
-6. Enter a suitable name for your app, such as *GPTRAGTeams*, as the application name. Ensure that you use only alphanumeric characters. Press **Enter**.
+| Path | Purpose |
+| ---- | ------- |
+| `src/app/app.ts` (or `src/index.ts`) | Teams AI Library `Application` instance — the entry point for all messages. |
+| `src/prompts/chat/` | Prompt templates and `config.json` (system prompt + model parameters). |
+| `appPackage/manifest.json` | Teams app manifest. **Confirm `"manifestVersion": "1.19"` or later**; bump it if the toolkit generated an older version. |
+| `m365agents.yml` (formerly `teamsapp.yml`) | Toolkit lifecycle definition: `provision`, `deploy`, `publish`. |
+| `infra/` | Bicep for the bot's Azure resources (Bot Service registration, optional App Service Plan / Function App). We will **trim this** in [Step 3](TEAMS_INTEGRATION_STEP3.md) to reuse existing accelerator infra. |
+| `env/` | Per-environment config (`.env.local`, `.env.dev`, etc.). |
 
-![Application Name](../media/teams-guide-Step1e.png)
+### 1.4 Confirm the SDK versions
 
-Proceed to Step 2: [Connect to GPT-RAG Orchestrator and test locally](TEAMS_INTEGRATION_STEP2.md).
+Open `package.json` and verify dependency versions roughly match:
+
+```jsonc
+{
+  "dependencies": {
+    "@microsoft/teams-ai": "^2.0.0",            // Teams AI Library v2
+    "@microsoft/agents-bot-hosting": "^1.0.0",  // M365 Agents SDK runtime (replaces botbuilder-* in maintenance)
+    "botbuilder": "^4.22.0",                    // still present for Activity types
+    "express": "^4.x",
+    "restify": "^11.x"
+  }
+}
+```
+
+If `@microsoft/teams-ai` is at a `1.x` version, run `npm install @microsoft/teams-ai@latest` — the streaming, citation and feedback APIs used in [Step 2](TEAMS_INTEGRATION_STEP2.md) and [Step 6](TEAMS_INTEGRATION_STEP6.md) are v2-only.
+
+---
+
+Proceed to [Step 2: Connect to GPT-RAG Orchestrator and test locally](TEAMS_INTEGRATION_STEP2.md).
 
 ## Additional Resources
-- [Prerequisites - Guide for Building a Teams App Interface for the Enterprise GPT-RAG Solution Accelerator](TEAMS_INTEGRATION_MAIN.md#prerequisites).
+- [Prerequisites - main guide](TEAMS_INTEGRATION_MAIN.md#prerequisites).
 - [Step 2: Connect to GPT-RAG Orchestrator and test locally](TEAMS_INTEGRATION_STEP2.md).
+- [Step 6: Add rich RAG UX](TEAMS_INTEGRATION_STEP6.md).
 
 ## External Resources
-- [Install Teams Toolkit](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/install-teams-toolkit?tabs=vscode).
-- [Prepare to build apps using Teams Toolkit](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/build-environments).
-- [Prerequisites for creating your Teams app](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/tools-prerequisites).
-- [Directory structure for different app types](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/create-new-project#directory-structure-for-different-app-types).
+- [Install the Microsoft 365 Agents Toolkit](https://learn.microsoft.com/microsoftteams/platform/toolkit/install-teams-toolkit?tabs=vscode).
+- [Teams AI Library overview](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/teams%20conversational%20ai/teams-conversation-ai-overview).
+- [Custom Engine Agents for Microsoft 365 Copilot](https://learn.microsoft.com/microsoft-365-copilot/extensibility/overview-custom-engine-agent).
+- [Manifest schema v1.19+](https://learn.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema).
+- [Directory structure for app types](https://learn.microsoft.com/microsoftteams/platform/toolkit/create-new-project#directory-structure-for-different-app-types).

--- a/docs/TEAMS_INTEGRATION_STEP2.md
+++ b/docs/TEAMS_INTEGRATION_STEP2.md
@@ -1,59 +1,166 @@
 # Guide for Building a Teams App Interface for Enterprise GPT-RAG Solution Accelerator
 
-*Ensure all steps mentioned in [Step 1](TEAMS_INTEGRATION_STEP1.md) are completed before proceeding with the steps below.*
+*Ensure all steps in [Step 1](TEAMS_INTEGRATION_STEP1.md) are completed before proceeding.*
 
-## Step 2: Connect to GPT-RAG Orchestrator and test locally
+## Step 2: Connect to the GPT-RAG Orchestrator and test locally
 
-1. Navigate to the `teamsBot.ts` file. Modify the code to pass the message to the Orchestrator and obtain a response. Below is a sample code snippet to guide you:
+In this step you replace the template's default LLM call with a call to the **GPT-RAG Orchestrator**, while keeping the Teams AI Library `Application` so that you inherit streaming, citation and feedback support out of the box (configured in [Step 6](TEAMS_INTEGRATION_STEP6.md)).
+
+> **Why not just `fetch()` like the previous version?** A raw `fetch()` in `teamsBot.ts` works, but it bypasses everything the Teams AI Library gives you for free: typed activity handlers, automatic state/turn management, the streaming response builder, and the citation / feedback APIs. Using the `Application` primitive now means [Step 6](TEAMS_INTEGRATION_STEP6.md) is mostly a configuration change rather than a rewrite.
+
+### 2.1 Configure the orchestrator endpoint
+
+Add the orchestrator settings to **`env/.env.local`** (and to the per-environment files later):
+
+```dotenv
+# Orchestrator
+ORCHESTRATOR_ENDPOINT=https://<your-orchestrator-host>/api/orc
+ORCHESTRATOR_AUDIENCE=api://<orchestrator-app-id>     # used by Step 6 (SSO/OBO)
+ORCHESTRATOR_TIMEOUT_MS=60000
+
+# Key Vault (optional — only if you keep a fallback API key)
+KEYVAULT_NAME=<your-kv-name>
+ORCHESTRATOR_KEY_SECRET_NAME=orchestrator-function-key
+```
+
+> **Do not check secrets into source.** The toolkit-generated `.gitignore` already excludes `env/.env.*.user`. Per-environment user secrets belong in `env/.env.<env>.user`, which the toolkit encrypts when committed.
+
+### 2.2 Create an orchestrator client
+
+Create **`src/orchestrator/client.ts`**:
 
 ```typescript
-        //await context.sendActivity(`Echo: ${txt}`);
+import { DefaultAzureCredential } from "@azure/identity";
 
-        // Obtain the orchestrator endpoint securely from Azure KeyVault
-        const orchestratorEndpoint = //Obtained from Azure KeyVault;
+export interface OrchestratorRequest {
+  question: string;
+  conversation_id: string;
+  user_id?: string;
+  user_token?: string; // populated in Step 6 once SSO is wired up
+}
 
-        // Retrieve the unique conversation ID from the activity context
-        const conversation_id = context.activity.conversation.id;
+export interface OrchestratorCitation {
+  title: string;
+  url?: string;
+  snippet?: string;
+  sensitivity_label?: string;
+}
 
-        // Construct the request body to send to the orchestrator
-        const requestBody = {
-            "question": txt, // The user's input text, which will be sent as the 'question'
-            "conversation_id": conversation_id 
-        };
+export interface OrchestratorResponse {
+  answer: string;
+  conversation_id: string;
+  citations?: OrchestratorCitation[];
+  thought_process?: string;
+}
 
-        try {
-            // Make a POST request to the orchestrator endpoint
-            const response = await fetch(orchestratorEndpoint, {
-                method: 'POST', // HTTP method to send the request
-                headers: {
-                    'Content-Type': 'application/json' // Specifies that the body of the request is in JSON format
-                },
-                body: JSON.stringify(requestBody) // Convert the request body into a JSON string
-            });
+const credential = new DefaultAzureCredential();
+const audience = process.env.ORCHESTRATOR_AUDIENCE!;
+const endpoint = process.env.ORCHESTRATOR_ENDPOINT!;
+const timeoutMs = Number(process.env.ORCHESTRATOR_TIMEOUT_MS ?? 60000);
 
-            // Check if the response was successful 
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
+export async function callOrchestrator(
+  req: OrchestratorRequest
+): Promise<OrchestratorResponse> {
+  // Prefer a Managed-Identity-issued token over a function key.
+  const token = await credential.getToken(`${audience}/.default`);
 
-            // Parse the JSON response from the orchestrator
-            const data = await response.json();
-            // Send the answer from the orchestrator back to the user
-            await context.sendActivity(`${data.answer}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-        } catch (error) {
-            //Error posting question to Azure Function, handle gracefully.
-        } 
+  try {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token!.token}`,
+      },
+      body: JSON.stringify(req),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`Orchestrator HTTP ${res.status}: ${body.slice(0, 500)}`);
+    }
+    return (await res.json()) as OrchestratorResponse;
+  } finally {
+    clearTimeout(timer);
+  }
+}
 ```
-2. Select **Run** and then **Start Debugging**. Test the bot by asking questions relevant to the files uploaded to the GPT-RAG Solution Accelerator.
 
-![Debug Teams Chat Locally](../media/teams-guide-Step2b.png)
+> The client uses **Managed Identity** (`DefaultAzureCredential`) by default. Locally, `DefaultAzureCredential` falls back to your `az login` identity. In Azure, it uses the user-assigned Managed Identity attached to the host (configured in [Step 3](TEAMS_INTEGRATION_STEP3.md)). The Key Vault lookup pattern from earlier guide revisions is no longer needed unless you must support a function-key fallback.
 
-Proceed to Step 3: [Provision and Deploy the Azure resources for the Teams App](TEAMS_INTEGRATION_STEP3.md).
+### 2.3 Wire the orchestrator into the Teams AI `Application`
+
+Open **`src/app/app.ts`** (the file may be `src/index.ts` in some template versions) and replace the default `app.ai.prompt(...)` handler with a call to the orchestrator. A minimal v2 Teams AI Library handler looks like:
+
+```typescript
+import { Application, TurnContext } from "@microsoft/teams-ai";
+import { MemoryStorage } from "botbuilder";
+import { callOrchestrator } from "../orchestrator/client";
+
+export const app = new Application({
+  storage: new MemoryStorage(),
+  // AI/feedback/streaming options are added in Step 6
+});
+
+app.activity("message", async (context: TurnContext) => {
+  const question = (context.activity.text ?? "").trim();
+  if (!question) return;
+
+  const conversationId = context.activity.conversation.id;
+  const userId = context.activity.from?.aadObjectId ?? context.activity.from?.id;
+
+  // Show a "thinking" indicator while the orchestrator works.
+  await context.sendActivity({ type: "typing" });
+
+  try {
+    const result = await callOrchestrator({
+      question,
+      conversation_id: conversationId,
+      user_id: userId,
+      // user_token: populated in Step 6 once SSO is wired
+    });
+
+    // For now, send the answer as plain text.
+    // Step 6 replaces this with a streamed reply that includes citations,
+    // an "AI generated" label, and the feedback loop.
+    await context.sendActivity(result.answer);
+  } catch (err) {
+    console.error("Orchestrator call failed", err);
+    await context.sendActivity(
+      "Sorry — I couldn't reach the knowledge service. Please try again in a moment."
+    );
+  }
+});
+```
+
+Key points compared to the legacy `teamsBot.ts` sample:
+
+- **`conversation.id` is still the correlation key** — the orchestrator continues to manage history under that id, so prior conversation memory still works.
+- **Errors are surfaced**, not silently swallowed.
+- **Auth is token-based**, not key-based.
+- **No raw `fetch()` from the activity handler** — the orchestrator client is isolated and unit-testable.
+
+### 2.4 Test locally
+
+1. From the **Microsoft 365 Agents Toolkit** sidebar, choose **Debug → Debug in Microsoft 365 Agents Playground** (or **Debug in Teams (Edge/Chrome)**). The Playground is the modern replacement for the older "App Test Tool" and lets you exercise the bot without sideloading.
+2. Send a question that you know the indexed corpus can answer.
+3. Confirm the orchestrator is being called with `conversation_id` and that the answer is rendered in the chat.
+
+If the local run fails to authenticate to the orchestrator, run `az login` in a terminal and restart debugging — `DefaultAzureCredential` will then pick up your user identity.
+
+---
+
+Proceed to [Step 3: Provision and deploy Azure resources (reusing accelerator infra)](TEAMS_INTEGRATION_STEP3.md).
 
 ## Additional Resources
-- [Step 1: Create a new Teams App](TEAMS_INTEGRATION_STEP1.md).
-- [Step 3: Provision and Deploy the Azure resources for the Teams App](TEAMS_INTEGRATION_STEP3.md).
+- [Step 1: Create a new Teams app project](TEAMS_INTEGRATION_STEP1.md).
+- [Step 3: Provision and deploy Azure resources](TEAMS_INTEGRATION_STEP3.md).
+- [Step 6: Add rich RAG UX](TEAMS_INTEGRATION_STEP6.md).
 
 ## External Resources
-- [Teams App Test Tool](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/debug-your-teams-app-test-tool?tabs=vscode%2Cclijs).
+- [Microsoft 365 Agents Playground](https://learn.microsoft.com/microsoftteams/platform/toolkit/debug-your-teams-app-test-tool?tabs=vscode%2Cclijs).
+- [Teams AI Library `Application` reference](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/teams%20conversational%20ai/how-conversation-ai-core-capabilities).
+- [`DefaultAzureCredential` overview](https://learn.microsoft.com/azure/developer/javascript/sdk/authentication/credential-chains).

--- a/docs/TEAMS_INTEGRATION_STEP3.md
+++ b/docs/TEAMS_INTEGRATION_STEP3.md
@@ -1,73 +1,91 @@
 # Guide for Building a Teams App Interface for Enterprise GPT-RAG Solution Accelerator
 
-*Ensure all steps mentioned in [Step 2](TEAMS_INTEGRATION_STEP2.md) are completed before proceeding with the steps below.*
+*Ensure all steps in [Step 2](TEAMS_INTEGRATION_STEP2.md) are completed before proceeding.*
 
-- Note: When deploying Azure resources for the Teams app, such as the App Service Plan and App Service, you can utilize the resources already provisioned in the GPT-RAG Solution Accelerator.
+## Step 3: Provision and deploy Azure resources (reusing accelerator infra)
 
-## Step 3: Provision and Deploy the Azure resources for the Teams App
-1. Select the **Teams Toolkit** icon in the sidebar. Select **Sign in to Microsoft 365**. 
+The accelerator already provisions hardened, VNet-integrated compute and a private network path to the orchestrator. **Reuse those resources rather than letting the Agents Toolkit stand up a new public-facing App Service.** This keeps the bot inside the same security boundary as the rest of the GPT-RAG deployment and avoids opening a second egress path to Azure OpenAI.
 
-![Microsoft 365 Signin](../media/teams-guide-Step3a.png)
+### 3.1 Decide where the bot will run
 
-2. Your default web browser opens to let you sign in to the account. Sign in with Microsoft 365 account. Close the browser when prompted and return to Visual Studio Code.
+Pick the host that best matches your operational model:
 
-![VS Code Signin](../media/teams-guide-Step3b.png)
+| Option | When to choose it | Bicep reference |
+| ------ | ----------------- | --------------- |
+| **Reuse the existing App Service** | Default. The accelerator's web frontend host already has VNet integration, Managed Identity, App Insights and Key Vault wiring. | [`infra/core/host/appservice.bicep`](../infra/core/host/appservice.bicep) |
+| **Reuse the existing Function App** | You prefer a serverless model and your traffic is bursty. | [`infra/core/host/functions.bicep`](../infra/core/host/functions.bicep) |
+| **New App Service / Function App / Container App** | You need strict isolation between the Teams bot and the web frontend (separate identity, separate scaling, separate deployment cadence). | New module under `infra/core/host/`. |
 
-3. Select the **Teams Toolkit** icon in the sidebar. Select **Sign in to Azure**. 
+Whichever option you choose, the **Azure Bot Service** registration is always new — there is one Bot Service per messaging endpoint.
 
-![Azure Signin](../media/teams-guide-Step3c.png)
+### 3.2 Trim the Agents Toolkit's default infrastructure
 
-4. Your default web browser opens to let you sign in to the account. Sign in to your Azure account. Close the browser when prompted and return to Visual Studio Code.
+The scaffolded `infra/` folder under the Teams project assumes a standalone deployment. Edit it so that **only the Bot Service registration and role assignments are created by the toolkit**, and the compute target is referenced by resource id.
 
-5. Select Provision from the LIFECYCLE section in the left pane.
+Edit `m365agents.yml` (formerly `teamsapp.yml`) so the `provision` lifecycle only:
 
-![Lifecycle Provision](../media/teams-guide-Step3d.png)
+1. Reads the existing compute resource id (App Service or Function App) from the environment file.
+2. Creates / updates the **Azure Bot Service** registration, pointing its **messaging endpoint** to `https://<existing-host>/api/messages`.
+3. Creates / updates the bot's **Entra ID app registration** (used by the messaging endpoint and by SSO in [Step 6](TEAMS_INTEGRATION_STEP6.md)).
+4. Assigns the **existing user-assigned Managed Identity** to the bot host (no new identity).
+5. Grants that Managed Identity the **role on the orchestrator** required to call it (e.g. a custom role, or `Cognitive Services User` if the orchestrator wraps Azure OpenAI directly).
 
-6. Select the Azure subscription. 
+Add the following to `env/.env.<env>` to point the toolkit at the accelerator's resources:
 
-![Azure Subscription Selection](../media/teams-guide-Step3e.png)
+```dotenv
+EXISTING_RESOURCE_GROUP=<rg-of-accelerator>
+EXISTING_APP_SERVICE_ID=/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Web/sites/<webapp>
+EXISTING_USER_ASSIGNED_MI_ID=/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<mi>
+ORCHESTRATOR_RESOURCE_ID=/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Web/sites/<orchestrator-func>
+```
 
-7. Select an existing resource group or create a new resource group. Press **Enter**.
+> The existing App Service / Function App must have a **path** free for the bot's `/api/messages` route. If the host is already serving the GPT-RAG web frontend on `/`, the bot can co-exist on `/api/messages`; otherwise, choose the Function App or stand up a dedicated host.
 
-![Resource group selection](../media/teams-guide-Step3f.png)
+### 3.3 Keep the bot's outbound traffic private
 
-![Resource group creation](../media/teams-guide-Step3g.png)
+The bot's **inbound** messaging endpoint must be reachable from the Bot Service (i.e. the public internet, optionally protected by Front Door + WAF). The bot's **outbound** traffic to the orchestrator should stay on the VNet:
 
-8. Select the Azure location.
+- Confirm the host has **VNet integration** enabled against the accelerator's VNet (see [`infra/core/network/vnet.bicep`](../infra/core/network/vnet.bicep)).
+- Confirm a **private endpoint** for the orchestrator exists in that VNet, and that the corresponding **Private DNS Zone** ([`infra/core/network/private-dns-zones.bicep`](../infra/core/network/private-dns-zones.bicep)) resolves the orchestrator hostname to the private IP.
+- Set `WEBSITE_VNET_ROUTE_ALL=1` (App Service) or `vnetRouteAllEnabled: true` (Function App) so all egress goes through the VNet.
 
-9. Review the message and select **Provision**.
+### 3.4 Provision and deploy
 
-![Provision button](../media/teams-guide-Step3h.png)
+1. Open the **Microsoft 365 Agents Toolkit** sidebar.
+2. **Sign in to Microsoft 365** and **Sign in to Azure**.
+3. Choose **Provision** under the **Lifecycle** section. Select the subscription and the **existing resource group** that holds the accelerator. The toolkit will create the Bot Service registration and the Entra ID app, and bind them to the existing host.
+4. Once provisioning completes, choose **Deploy**. This packages the Node.js app and deploys it into the existing App Service / Function App.
+5. In the Azure Portal, confirm:
+   - The Bot Service shows **Messaging endpoint** = `https://<existing-host>/api/messages` and **Microsoft App ID** = the toolkit-created app registration.
+   - The host has the **user-assigned Managed Identity** attached.
+   - **App settings** include `ORCHESTRATOR_ENDPOINT`, `ORCHESTRATOR_AUDIENCE`, and (if needed) `KEYVAULT_NAME`.
 
-10. Wait for the provisioning process to complete. 
+### 3.5 Smoke test
 
-![Provisioning status](../media/teams-guide-Step3i.png)
+From a Teams client where you've sideloaded the previous Step 2 build, send a question. Tail the host's **Application Insights** (`requests`, `dependencies`, `traces`) and confirm:
 
-![Provision complete](../media/teams-guide-Step3j.png)
+- The bot received the message activity.
+- The outbound call to the orchestrator left over the **private endpoint** (the dependency target should be the private FQDN).
+- A response was returned to the user within `ORCHESTRATOR_TIMEOUT_MS`.
 
-11. You can review the deployed Azure resources on the Azure portal.
+---
 
-![Azure resources on portal](../media/teams-guide-Step3k.png)
-
-12. Select Deploy from the LIFECYCLE section in the left pane.
-
-![Teams Deploy](../media/teams-guide-Step3l.png)
-
-13. Select Deploy.
-
-![Deploy button](../media/teams-guide-Step3m.png)
-
-13. Wait for the deployment to complete.
-
-![Deployment status](../media/teams-guide-Step3n.png)
-
-Proceed to Step 4: [Build the Teams App](TEAMS_INTEGRATION_STEP4.md).
-
+Proceed to [Step 4: Build the Teams app package](TEAMS_INTEGRATION_STEP4.md).
 
 ## Additional Resources
 - [Step 2: Connect to GPT-RAG Orchestrator and test locally](TEAMS_INTEGRATION_STEP2.md).
-- [Step 4: Build the Teams App](TEAMS_INTEGRATION_STEP4.md).
+- [Step 4: Build the Teams app package](TEAMS_INTEGRATION_STEP4.md).
+- [Step 6: Add rich RAG UX](TEAMS_INTEGRATION_STEP6.md).
+- Relevant accelerator Bicep:
+  [`infra/core/host/appservice.bicep`](../infra/core/host/appservice.bicep),
+  [`infra/core/host/functions.bicep`](../infra/core/host/functions.bicep),
+  [`infra/core/network/vnet.bicep`](../infra/core/network/vnet.bicep),
+  [`infra/core/network/private-dns-zones.bicep`](../infra/core/network/private-dns-zones.bicep),
+  [`infra/core/network/private-endpoint.bicep`](../infra/core/network/private-endpoint.bicep).
 
 ## External Resources
-- [Provision cloud resources](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/provision).
-- [Deploy Microsoft Teams app to the cloud](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/deploy).
+- [Provision cloud resources with the Agents Toolkit](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision).
+- [Deploy a Teams app to the cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy).
+- [Integrate App Service with an Azure virtual network](https://learn.microsoft.com/azure/app-service/overview-vnet-integration).
+- [Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options).
+- [Azure Bot Service messaging endpoint requirements](https://learn.microsoft.com/azure/bot-service/bot-builder-howto-deploy-azure).

--- a/docs/TEAMS_INTEGRATION_STEP4.md
+++ b/docs/TEAMS_INTEGRATION_STEP4.md
@@ -1,35 +1,58 @@
 # Guide for Building a Teams App Interface for Enterprise GPT-RAG Solution Accelerator
 
-*Ensure all steps mentioned in [Step 3](TEAMS_INTEGRATION_STEP3.md) are completed before proceeding with the steps below.*
+*Ensure all steps in [Step 3](TEAMS_INTEGRATION_STEP3.md) are completed before proceeding.*
 
-## Step 4: Build the Teams App
+## Step 4: Build the Teams app package
 
-1. Select the **Teams Toolkit** icon in the sidebar. Select **Utility** and then, **Zip Teams App Package**.
+The Teams app package is a `.zip` containing the manifest, icons, and (optionally) localization resources. It is what users sideload, and what you submit to the Developer Portal.
 
-![Zip Teams App Package](../media/teams-guide-Step4a.png)
+### 4.1 Confirm the manifest is up to date
 
-2. Select the Teams Manifest JSON file.
+Before zipping, open `appPackage/manifest.json` and verify:
 
-![Manifest file selection](../media/teams-guide-Step4b.png)
+- `"manifestVersion": "1.19"` (or later). v1.19+ is required for the `bots[].supportsStreaming`, `supportsAIGeneratedContent`, citation entities, and the feedback loop that [Step 6](TEAMS_INTEGRATION_STEP6.md) enables.
+- The bot's `botId` matches the Entra ID app registration created during provisioning.
+- `scopes` includes the surfaces you want — `personal` (1:1 chat), `team`, and/or `groupChat`.
+- For Custom Engine Agent reach into Microsoft 365 Copilot Chat, the `copilotAgents` section is present.
 
-3. Choose the environment. The Teams Toolkit supports running and testing your app in different deployment targets such as development, staging, production, or locally. It utilizes environment files to handle configurations and automate resource provisioning for various environments. Learn more about environments [here](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/teamsfx-multi-env).
+### 4.2 Zip the package
 
-![Teams Toolkit environment selection](../media/teams-guide-Step4c.png)
+1. Open the **Microsoft 365 Agents Toolkit** sidebar.
+2. Choose **Utility → Zip Teams App Package**.
 
-4. Wait for the build to complete. Once finished, navigate to the folder. You can click on the **local address** link to go directly to the folder.
+   ![Zip Teams App Package](../media/teams-guide-Step4a.png)
 
-![Local Address link](../media/teams-guide-Step4d.png)
+3. Select the **manifest JSON** file (`appPackage/manifest.json`).
 
-5. Review the files generated in the folder. These files will be used for deployment in the subsequent section.
+   ![Manifest file selection](../media/teams-guide-Step4b.png)
 
-![Teams App Files](../media/teams-guide-Step4e.png)
+4. Choose the **environment** (`local`, `dev`, `prod`, …). The toolkit substitutes environment-specific values (bot id, endpoint URLs) into the manifest at this point. See [Environments in the M365 Agents Toolkit](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-multi-env).
 
-Proceed to Step 5: [Publish the Teams App](TEAMS_INTEGRATION_STEP5.md).
+   ![Environment selection](../media/teams-guide-Step4c.png)
+
+5. Wait for the build to complete. The output `.zip` is written to `appPackage/build/appPackage.<env>.zip`.
+
+   ![Local Address link](../media/teams-guide-Step4d.png)
+
+6. Inspect the build output. You should see the zip alongside the rendered `manifest.<env>.json` — review that file to confirm the substituted bot id and endpoint look correct before publishing.
+
+   ![Teams App Files](../media/teams-guide-Step4e.png)
+
+### 4.3 Validate (optional but recommended)
+
+Run the Teams App validator before publishing — either via **Utility → Validate Application → Validate using App Validation Tool** in the toolkit, or via the [App validation page in the Developer Portal](https://dev.teams.microsoft.com/validation). It catches manifest issues that the toolkit does not (icon contrast, missing privacy URL, oversized descriptions, etc.).
+
+---
+
+Proceed to [Step 5: Publish the Teams app](TEAMS_INTEGRATION_STEP5.md).
 
 ## Additional Resources
-- [Step 3: Provision and Deploy the Azure resources for the Teams App](TEAMS_INTEGRATION_STEP3.md).
-- [Step 5: Publish the Teams App](TEAMS_INTEGRATION_STEP5.md).
+- [Step 3: Provision and deploy Azure resources](TEAMS_INTEGRATION_STEP3.md).
+- [Step 5: Publish the Teams app](TEAMS_INTEGRATION_STEP5.md).
+- [Step 6: Add rich RAG UX](TEAMS_INTEGRATION_STEP6.md).
 
 ## External Resources
-- [Teams app package](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/apps-package).
-- [Environments in Microsoft Teams Toolkit](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/teamsfx-multi-env).
+- [Teams app package](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/apps-package).
+- [App manifest schema reference (v1.19+)](https://learn.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema).
+- [Environments in the Microsoft 365 Agents Toolkit](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-multi-env).
+- [App validation in the Developer Portal](https://dev.teams.microsoft.com/validation).

--- a/docs/TEAMS_INTEGRATION_STEP5.md
+++ b/docs/TEAMS_INTEGRATION_STEP5.md
@@ -1,43 +1,70 @@
 # Guide for Building a Teams App Interface for Enterprise GPT-RAG Solution Accelerator
 
-*Ensure all steps mentioned in Step 4: [Build the Teams App](TEAMS_INTEGRATION_STEP4.md) are completed before proceeding with the steps below.*
+*Ensure all steps in [Step 4: Build the Teams app package](TEAMS_INTEGRATION_STEP4.md) are completed before proceeding.*
 
-## Step 5: Publish the Teams App
+## Step 5: Publish the Teams app
 
-You can follow the below steps to publish the Teams app at an individual level for testing purposes using the custom upload option:
+Once you have a packaged `.zip`, you have three publishing paths:
 
-1. In the Teams client or Teams web version, select **Apps** > **Manage your apps** > **Upload an app**. 
+| Path | Audience | When to use |
+| ---- | -------- | ----------- |
+| **Custom upload (sideload)** | The signed-in user only | Smoke testing on your own account. Requires custom upload to be enabled in the tenant. |
+| **Developer Portal → Publish to your org** | Whole tenant (after admin approval) | Production rollout inside your organization. |
+| **Developer Portal → Publish to the Teams Store** | Public | Only relevant if you intend to distribute the bot externally. Uncommon for GPT-RAG. |
 
-![Upload Teams App](../media/teams-guide-Step5a.png)
+### 5.1 Custom upload (individual testing)
 
-2. The Upload an app window appears. Select Upload a custom app.
+1. In the Teams client (desktop or web), select **Apps → Manage your apps → Upload an app**.
 
-![Upload a custom app](../media/teams-guide-Step5b.png)
+   ![Upload Teams App](../media/teams-guide-Step5a.png)
 
-3. Select the zip file generated in the previous section.
+2. Choose **Upload a custom app**.
 
-![Select Zip File](../media/teams-guide-Step5c.png)
+   ![Upload a custom app](../media/teams-guide-Step5b.png)
 
-4. Select the **Add** button.
+3. Select the `.zip` produced in [Step 4](TEAMS_INTEGRATION_STEP4.md) (e.g. `appPackage/build/appPackage.dev.zip`).
 
-![Add button](../media/teams-guide-Step5d.png)
+   ![Select Zip File](../media/teams-guide-Step5c.png)
 
-5. Wait for the app to be added successfully. 
+4. Click **Add**.
 
-![App Added Success](../media/teams-guide-Step5f.png)
+   ![Add button](../media/teams-guide-Step5d.png)
 
-6. Test the app by asking a question. 
+5. Wait for the app to install.
 
-![Test prompt](../media/teams-guide-Step5g.png)
+   ![App Added Success](../media/teams-guide-Step5f.png)
 
-![Chat Response](../media/teams-guide-Step5h.png)
+6. Open the bot, ask a question, and confirm the answer comes back from the orchestrator.
 
-To publish the Teams App to the developer portal, follow the steps outlined [here](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/publish-your-teams-apps-using-developer-portal).
+   ![Test prompt](../media/teams-guide-Step5g.png)
 
+   ![Chat Response](../media/teams-guide-Step5h.png)
+
+### 5.2 Tenant-wide publishing via the Developer Portal
+
+For a controlled tenant rollout:
+
+1. Open the [Developer Portal for Teams](https://dev.teams.microsoft.com/).
+2. **Apps → Import app** and upload your `.zip`.
+3. Run **App validation** and resolve any errors.
+4. **Publish → Publish to your org** to submit the app to your **Teams Admin Center → Manage apps** queue.
+5. A Teams admin reviews and approves; the app then appears in the **Built for your org** category for users in the tenant.
+
+Full instructions: [Publish a Teams app to your org](https://learn.microsoft.com/microsoftteams/platform/toolkit/publish-your-teams-apps-using-developer-portal).
+
+### 5.3 Custom Engine Agent in Microsoft 365 Copilot (optional)
+
+If you scaffolded the project as a **Custom Engine Agent** in [Step 1](TEAMS_INTEGRATION_STEP1.md), the same package also makes the bot available inside **Microsoft 365 Copilot Chat**. After tenant approval, users can `@`-mention the agent from Copilot Chat and reach the orchestrator without ever leaving Copilot. No separate codebase or hosting is required.
+
+---
+
+Once the bot is reachable in Teams, continue to [Step 6: Add rich RAG UX (citations, streaming, AI label, feedback, SSO)](TEAMS_INTEGRATION_STEP6.md) to turn the basic responder into a production-grade RAG agent.
 
 ## Additional Resources
-- [Step 4: Build the Teams App](TEAMS_INTEGRATION_STEP4.md).
+- [Step 4: Build the Teams app package](TEAMS_INTEGRATION_STEP4.md).
+- [Step 6: Add rich RAG UX](TEAMS_INTEGRATION_STEP6.md).
 
 ## External Resources
-- [Publish Teams apps using Teams Toolkit](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/publish#upload-app-package).
-- [Integrate with Developer Portal](https://learn.microsoft.com/en-us/microsoftteams/platform/toolkit/publish-your-teams-apps-using-developer-portal).
+- [Publish Teams apps using the Agents Toolkit](https://learn.microsoft.com/microsoftteams/platform/toolkit/publish#upload-app-package).
+- [Integrate with the Developer Portal](https://learn.microsoft.com/microsoftteams/platform/toolkit/publish-your-teams-apps-using-developer-portal).
+- [Teams admin centre — manage custom apps](https://learn.microsoft.com/microsoftteams/manage-apps).

--- a/docs/TEAMS_INTEGRATION_STEP6.md
+++ b/docs/TEAMS_INTEGRATION_STEP6.md
@@ -1,0 +1,234 @@
+# Guide for Building a Teams App Interface for Enterprise GPT-RAG Solution Accelerator
+
+*Ensure all steps in [Step 5: Publish the Teams app](TEAMS_INTEGRATION_STEP5.md) are completed before proceeding.*
+
+## Step 6: Add rich RAG UX (citations, streaming, AI label, feedback, SSO)
+
+Steps 1–5 give you a working Teams bot that proxies questions to the GPT-RAG Orchestrator. This step turns it into a **production-grade RAG agent** by enabling the Teams chat affordances that users expect from a modern AI experience:
+
+- **Token streaming** — answers appear as they are generated.
+- **Citations** — numbered footnotes that open the source document on click.
+- **AI-generated content label** — a "AI generated" badge under each reply.
+- **Feedback loop** — thumbs-up / thumbs-down with an optional comment, posted back to the bot for logging.
+- **Adaptive Card rendering** — a structured card that exposes the orchestrator's `thought_process` behind a "View reasoning" toggle.
+- **Single Sign-On (Entra ID)** — flow the user's identity to the orchestrator via On-Behalf-Of so per-user security trimming works end-to-end.
+
+Each sub-section is independent — adopt them in any order — but enabling them all is recommended.
+
+---
+
+### 6.1 Update the manifest
+
+Open `appPackage/manifest.json` and ensure these fields are present:
+
+```jsonc
+{
+  "manifestVersion": "1.19",
+  "bots": [
+    {
+      "botId": "${{BOT_ID}}",
+      "scopes": ["personal", "groupChat", "team"],
+      "supportsStreaming": true,
+      "supportsAIGeneratedContent": true,
+      "supportsFiles": true
+    }
+  ]
+}
+```
+
+These flags are what unlock the streaming, AI label, file-upload, and citation behaviours below. Without them, Teams ignores the corresponding entities on outgoing activities.
+
+---
+
+### 6.2 Enable streaming
+
+Streaming is a property of the Teams AI Library `Application`, so wrapping the orchestrator call in a `streamingResponse` is enough:
+
+```typescript
+app.activity("message", async (context) => {
+  const question = (context.activity.text ?? "").trim();
+  if (!question) return;
+
+  const stream = context.streamingResponse;          // provided by Teams AI v2
+  stream.queueInformativeUpdate("Searching the knowledge base…");
+
+  const result = await callOrchestrator({
+    question,
+    conversation_id: context.activity.conversation.id,
+    user_id: context.activity.from?.aadObjectId,
+    user_token: await getOboTokenForUser(context),    // see §6.6
+  });
+
+  // If the orchestrator returns the answer in chunks, queue each one;
+  // otherwise queue the whole answer as a single chunk.
+  stream.queueTextChunk(result.answer);
+
+  stream.setCitations((result.citations ?? []).map((c, i) => ({
+    "@type": "Claim",
+    position: i + 1,
+    appearance: {
+      "@type": "DigitalDocument",
+      name: c.title,
+      url: c.url,
+      abstract: c.snippet,
+      encodingFormat: "text/html",
+      usageInfo: c.sensitivity_label
+        ? { "@type": "CreativeWork", name: c.sensitivity_label }
+        : undefined,
+    },
+  })));
+
+  await stream.endStream({
+    generatedByAILabel: true,           // §6.4
+    feedbackLoop: { type: "default" },  // §6.5
+  });
+});
+```
+
+If your orchestrator currently returns one JSON blob, consider exposing an **SSE / chunked HTTP** endpoint so the bot can `queueTextChunk` per token. Even without true streaming from the orchestrator, the `queueInformativeUpdate` call alone removes most of the perceived latency.
+
+---
+
+### 6.3 Emit citations
+
+Citations come from the same `setCitations` call shown above. The orchestrator already returns retrieved chunks; expose them in the response shape used in [Step 2](TEAMS_INTEGRATION_STEP2.md):
+
+```jsonc
+{
+  "answer": "…with inline references like [1] and [2].",
+  "citations": [
+    {
+      "title": "Employee Handbook 2026",
+      "url": "https://contoso.sharepoint.com/.../handbook.pdf",
+      "snippet": "Employees accrue 20 days of annual leave per year…",
+      "sensitivity_label": "Confidential"
+    },
+    {
+      "title": "HR Policy 14.2",
+      "url": "https://contoso.sharepoint.com/.../policy-14-2.aspx",
+      "snippet": "Annual leave carry-over is capped at five days…"
+    }
+  ]
+}
+```
+
+When the user clicks `[1]` in the rendered answer, Teams opens a side card with the title, snippet, sensitivity label and link — i.e. **users can view the source documents directly from the chat**. The `position` number on each citation must match the inline `[n]` markers in the answer text; ensure the orchestrator's prompt instructs the model to insert `[n]` markers in order.
+
+---
+
+### 6.4 AI-generated content label
+
+The label is enabled in two places:
+
+- `supportsAIGeneratedContent: true` in the manifest (§6.1).
+- `generatedByAILabel: true` in the `endStream` call (§6.2), or `entities: [{ type: "https://schema.org/Message", "@context": "https://schema.org", additionalType: ["AIGeneratedContent"] }]` on a non-streamed activity.
+
+Apply the label to **all** model-generated replies. Do **not** apply it to deterministic responses (e.g. "Sorry, I couldn't reach the knowledge service") — those are not AI-generated.
+
+---
+
+### 6.5 Feedback loop
+
+With `feedbackLoop: { type: "default" }` (§6.2) — or `feedbackLoopEnabled: true` on a non-streamed activity — Teams renders 👍 / 👎 controls and an optional comment dialog under each AI reply. When the user reacts, Teams sends an `invoke` activity of name `message/submitAction` back to the bot. Handle it and persist:
+
+```typescript
+app.feedbackLoop(async (context, _state, feedback) => {
+  await persistFeedback({
+    conversationId: context.activity.replyToId,
+    userId: context.activity.from?.aadObjectId,
+    rating: feedback.actionValue.reaction,        // "like" | "dislike"
+    comment: feedback.actionValue.feedback,       // free text or undefined
+    timestamp: new Date().toISOString(),
+  });
+});
+```
+
+Persist feedback into **Cosmos DB** (the same account the accelerator already uses for conversations) and emit a custom event into **Application Insights** for offline evaluation pipelines and prompt tuning.
+
+---
+
+### 6.6 Single Sign-On + On-Behalf-Of
+
+So that the orchestrator can apply **per-user security trimming** (see [`docs/CUSTOMIZATIONS_SEARCH_TRIMMING.md`](CUSTOMIZATIONS_SEARCH_TRIMMING.md)), the bot must call the orchestrator **as the user**, not as itself.
+
+1. **Enable Teams SSO** during provisioning. The Agents Toolkit's `m365agents.yml` has an `aadApp/create` and `aadApp/update` action that creates the bot's Entra ID app registration and exposes a scope (e.g. `access_as_user`). Add the orchestrator's app id to the `knownClientApplications`.
+2. **Add SSO to the manifest**:
+
+   ```jsonc
+   {
+     "webApplicationInfo": {
+       "id": "${{AAD_APP_CLIENT_ID}}",
+       "resource": "api://botid-${{BOT_ID}}"
+     }
+   }
+   ```
+
+3. **Acquire a user token** at the start of each turn:
+
+   ```typescript
+   import { OnBehalfOfUserCredential } from "@microsoft/teamsfx";
+
+   async function getOboTokenForUser(context: TurnContext): Promise<string> {
+     const ssoToken = await context.adapter.getUserToken(
+       context, "graph", undefined
+     );
+     const credential = new OnBehalfOfUserCredential(ssoToken.token, {
+       authorityHost: "https://login.microsoftonline.com",
+       tenantId: process.env.AAD_APP_TENANT_ID!,
+       clientId: process.env.AAD_APP_CLIENT_ID!,
+       clientSecret: process.env.AAD_APP_CLIENT_SECRET!,
+     });
+     const orchestratorToken = await credential.getToken(
+       `${process.env.ORCHESTRATOR_AUDIENCE}/.default`
+     );
+     return orchestratorToken!.token;
+   }
+   ```
+
+4. **Forward the user token** to the orchestrator (the `user_token` field already plumbed through `callOrchestrator` in [Step 2](TEAMS_INTEGRATION_STEP2.md)). Update the orchestrator to read this token and use its `oid` / `groups` claims for AI Search security trimming.
+
+If the user has not yet consented to the bot, `getUserToken` returns `null`. Reply with an OAuth card (`CardFactory.oauthCard`) to prompt for consent — the Teams AI Library has an `app.authentication` helper that wraps this pattern.
+
+---
+
+### 6.7 Adaptive Card rendering of the structured response
+
+For richer answers — especially NL2SQL results, multi-step reasoning, or answers with many citations — render the response as an Adaptive Card 1.5 instead of plain text. Wrap the streaming reply with a final Adaptive Card that exposes:
+
+- The headline answer.
+- A **collapsible "Show sources"** section listing each citation as an `Action.OpenUrl`.
+- A **collapsible "View reasoning"** section that renders `result.thought_process` (for debugging / power users — gate this on a feature flag and never expose it externally).
+- **Suggested follow-up questions** as `Action.Submit` buttons (the orchestrator can return up to three follow-ups in a `suggested_followups` field).
+
+Keep card payloads under the **28 KB Teams activity limit** — for very long answers, keep the streamed text as the primary surface and use the card only for the metadata (sources, followups, reasoning toggle).
+
+---
+
+### 6.8 Putting it all together — checklist
+
+Before declaring the Teams experience production-ready:
+
+- [ ] `manifestVersion` ≥ `1.19` and the four `supports*` flags are set (§6.1).
+- [ ] All AI replies use `streamingResponse` and call `endStream({ generatedByAILabel: true, feedbackLoop: { type: "default" } })` (§§6.2, 6.4, 6.5).
+- [ ] The orchestrator returns `citations[]` and the bot maps them with `setCitations` (§6.3).
+- [ ] Feedback events are persisted to Cosmos and surfaced in App Insights (§6.5).
+- [ ] SSO is enabled, OBO tokens are forwarded, and the orchestrator honours the user's identity for security trimming (§6.6).
+- [ ] Adaptive Cards are used for structured responses; long answers stay below the 28 KB activity limit (§6.7).
+- [ ] All deterministic / error replies do **not** carry the AI-generated label.
+- [ ] App Insights dashboards exist for: turn count, average orchestrator latency, error rate, thumbs-down rate, and SSO consent failures.
+
+---
+
+## Additional Resources
+- [Step 5: Publish the Teams app](TEAMS_INTEGRATION_STEP5.md).
+- [`docs/CUSTOMIZATIONS_SEARCH_TRIMMING.md`](CUSTOMIZATIONS_SEARCH_TRIMMING.md) — per-user security trimming on AI Search.
+- [`docs/QUERYING_CONVERSATIONS.md`](QUERYING_CONVERSATIONS.md) — schema for Cosmos conversation/feedback documents.
+
+## External Resources
+- [Stream bot messages](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/bot-messages-ai-generated-content#stream-bot-messages).
+- [Format AI bot messages — citations and AI-generated label](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/bot-messages-ai-generated-content).
+- [Collect feedback from users](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/conversations/conversation-messages?tabs=dotnet#feedback-buttons).
+- [Teams SSO for bots](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/authentication/bot-sso-overview).
+- [On-Behalf-Of flow with `@microsoft/teamsfx`](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on).
+- [Adaptive Cards in Teams](https://learn.microsoft.com/microsoftteams/platform/task-modules-and-cards/cards/cards-reference).
+- [Custom Engine Agents for Microsoft 365 Copilot](https://learn.microsoft.com/microsoft-365-copilot/extensibility/overview-custom-engine-agent).


### PR DESCRIPTION
This pull request significantly updates the documentation for SharePoint ingestion and Teams app integration to reflect current best practices, clarify operational details, and guide users toward modern tooling and infrastructure reuse. The changes provide clearer, more accurate instructions for setting up SharePoint as a data source and for building a Teams interface using the latest Microsoft 365 Agents Toolkit and Teams AI Library v2.

**SharePoint Ingestion Documentation Improvements:**

- **Clarified SharePoint connector architecture and version pinning:** The documentation now explicitly describes the "pull-from-SharePoint, push-to-Search" model, details the use of scheduled Azure Functions, and notes that this fork is pinned to the `gpt-rag-ingestion` `release/1.0.1` branch, with all instructions and environment variables matched to this version. It also warns that newer upstream releases may differ. [[1]](diffhunk://#diff-49cd8b759265ca93415f24f09658c92b903bc478b98426fa3841741f746fa772L1055-R1055) [[2]](diffhunk://#diff-6a42f9a0fceb5198d39af0985840f3b82135d32c6978660cb736dd6af20dc3d7R5-R40)
- **Added known limits and operational notes:** The guide now lists important limitations of the 1.0.1 connector, such as single site/folder support, lack of Graph paging, duplicate index entries on moves/renames, Graph throttling handling, partial ACL capture, Function App plan requirements, and client secret rotation caveats.
- **Provided tips and notes for deployment:** Additional tips clarify how to set a custom target index and verify function schedules, helping users avoid common misconfigurations.

**Teams App Integration Guide Overhaul:**

- **Modernized Teams app setup instructions:** The Teams integration documentation now targets the Microsoft 365 Agents Toolkit (formerly Teams Toolkit) and Teams AI Library v2, replacing legacy Bot Framework/Basic Bot flows. It emphasizes infrastructure reuse, SSO, and private connectivity, and provides a step-by-step outline for building, deploying, and enhancing the Teams app.
- **Detailed, up-to-date project scaffolding guide:** Step 1 has been rewritten to guide users through creating a Teams app project using the new toolkit, including template selection, SDK version checks, and post-scaffold verification.

These updates ensure that users have reliable, future-proof instructions for both SharePoint ingestion and Teams integration, aligned with current Microsoft tooling and deployment patterns.